### PR TITLE
Fix problem where Excel files couldn't be opened in Office 2010

### DIFF
--- a/OLE/PPS/Root.php
+++ b/OLE/PPS/Root.php
@@ -620,7 +620,7 @@ class OLE_PPS_Root extends OLE_PPS
       else
         fwrite($FILE, pack("V", -2));
 
-      fwrite($FILE, pack("V", 1));
+      fwrite($FILE, pack("V", $num_sb_blocks));
 
       // Extra BDList Start, Count
       if($bbd_info["blockchain_list_entries"] < $bbd_info["header_blockchain_list_entries"])


### PR DESCRIPTION
I haven't traced the problem, the fix is from one of the comments of http://pear.php.net/bugs/bug.php?id=19284, but for me, this reproducably fixes the issue the Excel 2010 refuses to open the files because they are corrupt
