### PR TITLE
Constructors for all classes

### DIFF
--- a/OLE.php
+++ b/OLE.php
@@ -98,7 +98,7 @@ class OLE extends PEAR
     * Creates a new OLE object
     * @access public
     */
-    function OLE()
+    function __construct()
     {
         $this->_list = array();
     }

--- a/OLE/PPS.php
+++ b/OLE/PPS.php
@@ -130,7 +130,7 @@ class OLE_PPS extends PEAR
     * @param string  $data  The (usually binary) source data of the PPS
     * @param array   $children Array containing children PPS for this PPS
     */
-    function OLE_PPS($No, $name, $type, $prev, $next, $dir, $time_1st, $time_2nd, $data, $children)
+    function __construct($No, $name, $type, $prev, $next, $dir, $time_1st, $time_2nd, $data, $children)
     {
         $this->No      = $No;
         $this->Name    = $name;

--- a/OLE/PPS/File.php
+++ b/OLE/PPS/File.php
@@ -50,7 +50,7 @@ class OLE_PPS_File extends OLE_PPS
     * @param string $name The name of the file (in Unicode)
     * @see OLE::Asc2Ucs()
     */
-    function OLE_PPS_File($name)
+    function __construct($name)
     {
         $system = new System();
         $this->_tmp_dir = $system->tmpdir();

--- a/OLE/PPS/Root.php
+++ b/OLE/PPS/Root.php
@@ -55,7 +55,7 @@ class OLE_PPS_Root extends OLE_PPS
     * @param integer $time_1st A timestamp
     * @param integer $time_2nd A timestamp
     */
-    function OLE_PPS_Root($time_1st, $time_2nd, $raChild)
+    function __construct($time_1st, $time_2nd, $raChild)
     {
         $system = new System();
         $this->_tmp_dir = $system->tmpdir();


### PR DESCRIPTION
PHP 7.0: 

> Methods with the same name as their class will not be constructors in a future version of PHP; OLE_PPS_File has a deprecated constructor