### PR TITLE
Actually call declared constructors

### DIFF
--- a/OLE/PPS/File.php
+++ b/OLE/PPS/File.php
@@ -54,7 +54,7 @@ class OLE_PPS_File extends OLE_PPS
     {
         $system = new System();
         $this->_tmp_dir = $system->tmpdir();
-        $this->OLE_PPS(
+        parent::__construct(
             null, 
             $name,
             OLE_PPS_TYPE_FILE,

--- a/OLE/PPS/Root.php
+++ b/OLE/PPS/Root.php
@@ -59,7 +59,7 @@ class OLE_PPS_Root extends OLE_PPS
     {
         $system = new System();
         $this->_tmp_dir = $system->tmpdir();
-        $this->OLE_PPS(
+        parent::__construct(
            null, 
            OLE::Asc2Ucs('Root Entry'),
            OLE_PPS_TYPE_ROOT,


### PR DESCRIPTION
Actually call declared constructors (introduced in #7) instead of old-style kind of constructors 
