### PR TITLE
Fix for PEAR bug #21243

### DIFF
--- a/OLE.php
+++ b/OLE.php
@@ -59,6 +59,12 @@ class OLE extends PEAR
     var $_file_handle;
 
     /**
+     * Reference to the sbat stream
+     * @var resource
+     */
+    var $_small_handle;
+
+    /**
     * Array of PPS's found on the OLE container
     * @var array
     */
@@ -339,6 +345,10 @@ class OLE extends PEAR
             $pps->Size = $this->_readInt4($fh);
             $pps->No = count($this->_list);
             $this->_list[] = $pps;
+
+            if ($type == OLE_PPS_TYPE_ROOT) {
+                $this->_small_handle = $this->getStream($pps->_StartBlock);
+            }
 
             // check if the PPS tree (starting from root) is complete
             if (isset($this->root) &&

--- a/OLE.php
+++ b/OLE.php
@@ -241,7 +241,8 @@ class OLE extends PEAR
         // in OLE_ChainedBlockStream::stream_open().
         // Object is removed from self::$instances in OLE_Stream::close().
         $GLOBALS['_OLE_INSTANCES'][] = $this;
-        $instanceId = end(array_keys($GLOBALS['_OLE_INSTANCES']));
+        $keys = array_keys($GLOBALS['_OLE_INSTANCES']);
+        $instanceId = end($keys);
 
         $path = 'ole-chainedblockstream://oleInstanceId=' . $instanceId;
         if (is_a($blockIdOrPps, 'OLE_PPS')) {

--- a/OLE/ChainedBlockStream.php
+++ b/OLE/ChainedBlockStream.php
@@ -109,12 +109,13 @@ class OLE_ChainedBlockStream extends PEAR
             $blockId != $this->ole->root->_StartBlock) {
 
             // Block id refers to small blocks
-            $rootPos = $this->ole->_getBlockOffset($this->ole->root->_StartBlock);
+            $rootPos = 0;
             while ($blockId != -2) {
-                $pos = $rootPos + $blockId * $this->ole->bigBlockSize;
-                $blockId = $this->ole->sbat[$blockId];
-                fseek($this->ole->_file_handle, $pos);
-                $this->data .= fread($this->ole->_file_handle, $this->ole->bigBlockSize);
+                $pos = $rootPos + $blockId * $this->ole->smallBlockSize;
+
+                $blockId = $this->ole->sbat[$blockId];                
+                fseek($this->ole->_small_handle, $pos);
+                $this->data .= fread($this->ole->_small_handle, $this->ole->smallBlockSize);
             }
         } else {
             // Block id refers to big blocks


### PR DESCRIPTION
This is a fix for [PEAR bug #21243 ](https://pear.php.net/bugs/bug.php?id=21243) along the lines of what the bug filer ``tacituseu`` suggested.

Background
---
OLE Compound documents have two different data streams, big block stream (bbat) and small block stream (sbat). Support for reading small data streams in ``PEAR::OLE`` is broken. It reads big blocks worth of data from the small block index. Sometimes this works, if the small blocks are contiguous within one big block's worth of data.

In fact, the small block stream should be read from the big block object pointed to by the Compound document's root element start block pointer.

Fix
---
Open the big block object containing the small block stream when the file is opened. Use that to read the small block stream in ``OLE_ChainedBlockStream::stream_open()``. 

Effectively this causes the entire big block object to be read to read any small block object. This object's data is cached in the ``data`` member of the stream object, so performance will be acceptable. However it may be problematic for extremely large Compound documents with extremely large small block streams. Though compare with the ``PhpSpreadsheet`` project which parses the entire Compound document into memory.


