### PR TITLE
Update SPDX License ID to match that of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pear/ole",
     "type": "library",
     "description": "This package allows reading and writing of OLE (Object Linking and Embedding) compound documents. This format is used as container for Excel (.xls), Word (.doc) and other Microsoft file formats.",
-    "license": "PHP-3.0",
+    "license": "PHP-3.01",
     "authors": [
         {
             "name": "Christian Schmidt",


### PR DESCRIPTION
- [PEAR's copyrights page](https://pear.php.net/copyright.php) links back to the [PHP Licensing](https://www.php.net/license/) page, which says that "PHP 4, PHP 5 and PHP 7 are distributed under the PHP License v3.01".
- `package.xml` also links to https://www.php.net/license/

Which facts make it seem that when I set the license identifier to the plain 3.0 in 6fef681543b5, I was mistaken. Therefore, this time we will correct this mistake.

See also https://github.com/pear/OLE/commit/de66fdf6a27651605b9667047657e18a9d846eca#commitcomment-34921820 by @tijuca