### PR TITLE
Add .gitattributes to exclude tests from release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Debug with: git archive --format=tar HEAD | tar t
+
+/tests                export-ignore


### PR DESCRIPTION
 - They cause issues with Composer 2 autoloading.
 - That's just a sensible thing to do.