### PR TITLE
Add Type Casting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          ini-values: error_reporting=E_ALL
           tools: composer:v2
           coverage: none
 

--- a/OLE.php
+++ b/OLE.php
@@ -561,12 +561,12 @@ class OLE extends PEAR
         $res = '';
 
         for ($i = 0; $i < 4; $i++) {
-            $hex = $low_part % 0x100;
+            $hex = (int) $low_part % 0x100;
             $res .= pack('c', $hex);
             $low_part /= 0x100;
         }
         for ($i = 0; $i < 4; $i++) {
-            $hex = $high_part % 0x100;
+            $hex = (int) $high_part % 0x100;
             $res .= pack('c', $hex);
             $high_part /= 0x100;
         }

--- a/OLE/ChainedBlockStream.php
+++ b/OLE/ChainedBlockStream.php
@@ -160,7 +160,10 @@ class OLE_ChainedBlockStream extends PEAR
         if ($this->stream_eof()) {
             return false;
         }
-        $s = substr($this->data, $this->pos ?? 0, $count);
+
+        $pos = isset($this->pos) ? $this->pos : 0;
+
+        $s = substr($this->data, $pos, $count);
         $this->pos += $count;
         return $s;
     }

--- a/OLE/ChainedBlockStream.php
+++ b/OLE/ChainedBlockStream.php
@@ -160,7 +160,7 @@ class OLE_ChainedBlockStream extends PEAR
         if ($this->stream_eof()) {
             return false;
         }
-        $s = substr($this->data, $this->pos, $count);
+        $s = substr($this->data, $this->pos ?? 0, $count);
         $this->pos += $count;
         return $s;
     }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" verbose="true" colors="true"
-        convertNoticesToExceptions="true"
+		convertNoticesToExceptions="true"
 		convertDeprecationsToExceptions="true"
 >
 	<testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" verbose="true" colors="true"
-         convertNoticesToExceptions="true"
+        convertNoticesToExceptions="true"
+		convertDeprecationsToExceptions="true"
 >
 	<testsuites>
 		<testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" verbose="true" colors="true"
-		convertNoticesToExceptions="true"
-		convertDeprecationsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertDeprecationsToExceptions="true"
 >
 	<testsuites>
 		<testsuite>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php" verbose="true" colors="true"
          convertNoticesToExceptions="true"
-         convertDeprecationsToExceptions="true"
 >
 	<testsuites>
 		<testsuite>


### PR DESCRIPTION
There were some deprecation warnings when I was using this suite, so submitted this patch.

https://github.com/nick322/secure-spreadsheet/actions/runs/5210606717/jobs/9401954038

Add Type Casting to avoid "Deprecated: Implicit conversion from float X to int loses precision in" in PHP version > 8.1.
