### PR TITLE
PLEASE release a stable version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,10 @@
     "support": {
         "issues": "http://pear.php.net/bugs/search.php?cmd=display&package_name[]=OLE",
         "source": "https://github.com/pear/OLE"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.0"
+        }
     }
 }


### PR DESCRIPTION
Other packages that require this one cause Composer to complain about a dependency being not stable enough, if you require only stable packages in your project.

Since I am terribly unable to properly report a bug in the PEAR website, because of multiple email failures, I'm submitting a PR in hopes of this simple issue being looked into. I don't think this PR is the correct solution, but instead a new release `v1.0.0` should be properly created. There are many years this package is in RC state and this only harms the Composer community and depending packages.