### PR TITLE
Update package.xml for PEAR release 1.0.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -16,19 +16,23 @@
   <email>xnoguer@php.net</email>
   <active>no</active>
  </lead>
- <date>2017-06-20</date>
+ <date>2024-01-18</date>
  <version>
-  <release>1.0.0RC3</release>
-  <api>1.0.0RC3</api>
+  <release>1.0.0</release>
+  <api>1.0.0</api>
  </version>
  <stability>
-  <release>beta</release>
-  <api>beta</api>
+  <release>stable</release>
+  <api>stable</api>
  </stability>
  <license uri="http://www.php.net/license">PHP</license>
  <notes>
-Bug #19284:  RC2 breaks header in excel files from Spreadsheet_Excel_Writer
-Bug #21216:  Call to undefined method PEAR::OLE_PPS()
+- Stable release after 9 release candidates
+- Resolved PHP 8 deprecations  
+- Full compatibility with PHP 5.6 through PHP 8.2
+- Changes to comply with MS documentation
+- Added type casting improvements
+- Fixed PHP 7.4 compatibility issues
  </notes>
  <contents>
   <dir baseinstalldir="/" name="/">
@@ -42,7 +46,7 @@ Bug #21216:  Call to undefined method PEAR::OLE_PPS()
  <dependencies>
   <required>
    <php>
-    <min>5.0.0</min>
+    <min>5.6.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>
@@ -206,6 +210,26 @@ Bug #17685 OLE doesn&apos;t save multistreams
    <notes>
 Bug #19284:  RC2 breaks header in excel files from Spreadsheet_Excel_Writer
 Bug #21216:  Call to undefined method PEAR::OLE_PPS()
+   </notes>
+  </release>
+  <release>
+   <version>
+    <release>1.0.0</release>
+    <api>1.0.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <date>2024-01-18</date>
+   <license uri="http://www.php.net/license">PHP</license>
+   <notes>
+- Stable release after 9 release candidates
+- Resolved PHP 8 deprecations  
+- Full compatibility with PHP 5.6 through PHP 8.2
+- Changes to comply with MS documentation
+- Added type casting improvements
+- Fixed PHP 7.4 compatibility issues
    </notes>
   </release>
  </changelog>


### PR DESCRIPTION
Fixes #34


- Update version from 1.0.0RC3 to 1.0.0 (stable)
- Update release date to 2024-01-18 (matching GitHub release)
- Update PHP minimum version to 5.6 (matching composer.json)
- Add comprehensive release notes covering changes since RC3
- Add changelog entry for 1.0.0 release

This syncs the PEAR release with the existing GitHub v1.0.0 release.

### Next Steps After Merge

1. Pull merged changes: `git checkout master && git pull`
2. Build package: `pear package` (creates `OLE-1.0.0.tgz`)
3. Upload to PEAR:
   - Log in at https://pear.php.net/
   - Go to Package Management → Upload Release
   - Upload the .tgz file
4. Verify at https://pear.php.net/package/OLE